### PR TITLE
Changed to use (my) fapi service, along with now having rich embeds

### DIFF
--- a/saucebot-discord.py3
+++ b/saucebot-discord.py3
@@ -12,47 +12,50 @@ import discord
 import re
 import requests
 import json
+import os
 
-discord_token = 'PASTE YOUR DISCORD BOT TOKEN HERE'
+discord_token = os.environ["DISCORD_API_KEY"]
 
-fa_pattern = re.compile('furaffinity\.net/view/\d+')
+fa_pattern = re.compile('(furaffinity\.net/view/(\d+))')
 
+fapi_url = "https://bawk.space/fapi/submission/{}"
 
 client = discord.Client()
 
+
 @client.event
 async def on_message(message):
-    
-    fa_dir_link_list = ''
-    
     # we do not want the bot to reply to itself
     if message.author == client.user:
         return
 
-    # Precheck for FA URL
-    if 'furaffinity.net/view/' in message.content:
-        # Check for all FA links in msg
-        fa_links = re.findall(fa_pattern, message.content)
-        
-        # Process each link
-        for (fa_link) in fa_links:
-            # Construct API request, chop apart FA URL
-            fa_link_url = 'https://faexport.boothale.net/submission/{}.json'.format(fa_link[21:])
-            
-            # Request submission info
-            fa_get = requests.get(fa_link_url)
+    fa_links = fa_pattern.findall(message.content)
 
-            # Check for success from API
-            if fa_get:
-                fa_get_dict = json.loads(fa_get.text)
-                    
-                # Compile URL list
-                fa_dir_link_list = fa_dir_link_list + ' ' + fa_get_dict['download']
+    # Process each link
+    for (fa_link, fa_id) in fa_links:
+        # Request submission info
+        fa_get = requests.get(fapi_url.format(fa_id))
 
-    # TODO: Add some additional features here: reverse source lookup, weasyl, etc.
-    
-        # Send the message to the right channel
-        await client.send_message(message.channel, fa_dir_link_list)
+        # Check for success from API
+        if not fa_get:
+            continue
+
+        fapi = json.loads(fa_get.text)
+        print(fapi)
+
+        em = discord.Embed(
+            title=fapi["title"])
+        # discord api does not like it when embed urls are set?
+        # it's not of critical importance as the original url will be near
+        # em.url = fa_link
+
+        em.set_image(url=fapi["image_url"])
+        em.set_author(
+            name=fapi["author"],
+            icon_url=fapi["avatar"])
+
+        await client.send_message(message.channel, embed=em)
+
 
 @client.event
 async def on_ready():


### PR DESCRIPTION
It seems that the previous web-scraping fa API-providing service has gone offline, for unknown reasons. It's perfectly possible to re-host it, but I decided to make my own, namely fapi. It provides only what saucebot needs for the time being, but can be extended.

Instead of sending direct image links and relying on discord to detect them and display them as such, saucebot now sends rich embeds, that include information about the author along with the same image as before. It's still getting the image from the same link, so nothing should change.

Also changed the manual "put thing here" message with an environment variable get. Just made more sense.