### PR TITLE
Fix condition for disabling preview activating when mentioning users/etc

### DIFF
--- a/saucebot-discord.py3
+++ b/saucebot-discord.py3
@@ -26,7 +26,7 @@ twitter_access_token_secret = os.environ["TWITTER_TOKEN_SECRET"]
 pixiv_login = os.environ['PIXIV_LOGIN']
 pixiv_password = os.environ['PIXIV_PASSWORD']
 
-disable_command_pattern = re.compile('<.*>')
+disable_command_pattern = re.compile('<(?!@|#|:|a:).*>')
 fa_pattern = re.compile('(furaffinity\.net/view/(\d+))')
 ws_pattern = re.compile('weasyl\.com\/~\w+\/submissions\/(\d+)')
 wschar_pattern = re.compile('weasyl\.com\/character\/(\d+)')


### PR DESCRIPTION
The condition to disable the bot previews checks if angular brackets meet _anywhere_ in the message, which ends up capturing mentions towards other users, roles, channels, or if custom emojis/animated nitro emojis are present anywhere in the message, as they respectively appear as `<@user_id>`, `<@&role_id>`, `<#channel_id>`, `<:emoji_id:>` and `<a:animated_emoji_id:>` in the `message.content`, all with meeting angular brackets.

I've changed `disable_command_pattern` to prevent returning a match if the character after the first bracket match any of the scenarios presented above. I don't have a running instance of the bot though so I haven't tested if it works but it should.