### PR TITLE
add instagram post support

### DIFF
--- a/saucebot-discord.py3
+++ b/saucebot-discord.py3
@@ -16,7 +16,9 @@ import os
 import pixivpy3
 import io
 from instalooter.looters import PostLooter
-#instalooter needs a user agent to tell instagram, drop user-agent.txt into ~/.cache/instalooter/{version}/
+# instalooter needs a user agent to tell instagram, add user-agent.txt with 
+# user agent (example: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:77.0) Gecko/20100101 Firefox/77.0) 
+# into ~/.cache/instalooter/{version}/
 
 #handle different ig links
 def links(media, looter):

--- a/saucebot-discord.py3
+++ b/saucebot-discord.py3
@@ -315,7 +315,7 @@ async def on_message(message):
         for media in looter.medias():
             for link in links(media, looter):
                 tex+="{}\n".format(link)
-        await ch.send(tex)
+        await message.channel.send(tex)
     
 
 

--- a/user-agent.txt
+++ b/user-agent.txt
@@ -1,0 +1,1 @@
+Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:77.0) Gecko/20100101 Firefox/77.0


### PR DESCRIPTION
since discord does not embed instagram posts i figured it would be nice for saucebot to grab the images, it also pulls videos. it does the links. note the library used, instalooter, needs a useragent for instagram so you'll need to put user-agent.txt in ~/.cache/instalooter/{version}/